### PR TITLE
chore: removed authorisation header

### DIFF
--- a/libs/blocks/form/form.js
+++ b/libs/blocks/form/form.js
@@ -1,10 +1,5 @@
 import sanitizeComment from '../../utils/sanitizeComment.js';
 import { createTag } from '../../utils/utils.js';
-import dotenv from 'dotenv';
-dotenv.config();
-
-const API_KEY = process.env.REACT_APP_API_KEY;
-console.log('Form API Key:', API_KEY);
 
 const RULE_OPERATORS = {
   equal: '=',
@@ -55,7 +50,6 @@ async function submitForm(form) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': "Y+IAXdbNFHyt/ihRsUZFP3fYKwATZ4QzAbiQrLsyWrw=", 
       },
       body: JSON.stringify(payload), 
     });


### PR DESCRIPTION
Removed the API_key imports due to the submission-worker being able to access the key secret of this repository, shortly said there would be no safe way to implement having imported the API_key in the frontend code.

URL: https://key-branch--apprentice-milo--t0risutan.aem.page/