### PR TITLE
chore: got rid of API_key header

### DIFF
--- a/libs/blocks/form/form.js
+++ b/libs/blocks/form/form.js
@@ -50,7 +50,6 @@ async function submitForm(form) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': API_KEY, 
       },
       body: JSON.stringify(payload), 
     });


### PR DESCRIPTION
Got rid of the API_key header

URL: https://key-branch--apprentice-milo--t0risutan.aem.page/